### PR TITLE
Windows XP にて MsDvbNp.ax が access violation を起こす現象に対処

### DIFF
--- a/BonDriver_BDA/BonTuner.cpp
+++ b/BonDriver_BDA/BonTuner.cpp
@@ -3499,6 +3499,19 @@ void CBonTuner::StopGraph(void)
 		SAFE_CLOSE_HANDLE(m_hStreamThread);
 		m_bIsSetStreamThread = FALSE;
 
+		// a workaround for WinXP SP3
+		// CBonTuner::LoadAndConnectDevice() にて動作するチューナが一つもなかったとき、
+		// m_pIMediaControl->Stop() の内部で MsDvbNp.ax が access violation を起こす。
+		// なので、Stop する必要のないときは何もしないようにする
+		OAFilterState fs;
+		if (FAILED(hr = m_pIMediaControl->GetState(100, &fs))) {
+			OutputDebug(L"IMediaControl::GetState failed.\n");
+		}
+		else {
+			if (fs == State_Stopped)
+				return;
+		}
+
 		if (FAILED(hr = m_pIMediaControl->Pause())) {
 			OutputDebug(L"IMediaControl::Pause failed.\n");
 		}


### PR DESCRIPTION
#8 に続いてもう一つWinXP関連のネタで申し訳ない。これはXPに付属の MsDvbNp.ax (NetworkProvider) のバグだと思うのですが、利用可能なチューナが一つもない状態だと MsDvbNp.ax が access violation を起こしてクラッシュしてしまいます。その後プロセスを強制終了させても何故か TvTest のプロセスが完全には終了せずに残ってしまったりするので、何らかの対処が必要と考え原因を調査して回避コードを入れました。

設定が完了していないフィルタグラフに対して Pause とかの操作をしているのがまずいようなので、状態を調べて元々停止状態の時は何もせず抜けるようにしました。