### PR TITLE
ヌルパケットを削除できるようにする、など

### DIFF
--- a/BonDriver_BDA/BonTuner.h
+++ b/BonDriver_BDA/BonTuner.h
@@ -117,6 +117,10 @@ protected:
 	// ini ファイル読込
 	void ReadIniFile(void);
 
+	// 電源プラン変更用
+	void PowerSetOnOpened(void);
+	void PowerSetOnClosing(void);
+
 	// 信号状態を取得
 	void GetSignalState(int* pnStrength, int* pnQuality, int* pnLock);
 
@@ -845,6 +849,16 @@ protected:
 	// チューナデバイス排他処理用
 	HANDLE m_hSemaphore;
 
+	// 電源プラン変更用のミューテックスオブジェクト名
+	// 他ツールと協調する場合に備えて、一般的な名前"PowerSet～"にランダムGUIDを付加して命名
+	static constexpr WCHAR POWER_SET_FLAG_NAME[] = L"Global\\PowerSetFlag-D112FE9C-2CC3-4AEE-83E3-458C65CF592C";
+	static constexpr WCHAR POWER_SET_LOCK_NAME[] = L"Global\\PowerSetLock-D112FE9C-2CC3-4AEE-83E3-458C65CF592C";
+	static constexpr DWORD POWER_SET_WAIT_MSEC = 10000;
+
+	// 電源プラン変更用
+	HANDLE m_hPowerSetFlag;
+	HANDLE m_hPowerSetLock;
+
 	// Graph
 	CComPtr<IGraphBuilder> m_pIGraphBuilder;	// Filter Graph Manager の IGraphBuilder interface
 	CComPtr<IMediaControl> m_pIMediaControl;	// Filter Graph Manager の IMediaControl interface
@@ -1046,6 +1060,10 @@ protected:
 
 	// フィルタグラフをRunningObjectTableに登録するかどうか
 	BOOL m_bRegisterGraphInROT;
+
+	// 電源プラン変更のGUID
+	std::wstring m_sPowerSetOnOpenedGUID;
+	std::wstring m_sPowerSetOnClosingGUID;
 
 	// Tuner is opened
 	BOOL m_bOpened;

--- a/BonDriver_BDA/BonTuner.h
+++ b/BonDriver_BDA/BonTuner.h
@@ -857,6 +857,9 @@ protected:
 	CComPtr<IBaseFilter> m_pDemux;				// MPEG2 Demultiplexer の IBaseFilter interface
 	CComPtr<IBaseFilter> m_pTif;				// MPEG2 Transport Information Filter の IBaseFilter interface
 
+	// RunningObjectTableの登録ID
+	DWORD m_dwROTRegister;
+
 	// チューナ信号状態取得用インターフェース
 	CComPtr<IBDA_SignalStatistics> m_pIBDA_SignalStatisticsTunerNode;
 	CComPtr<IBDA_SignalStatistics> m_pIBDA_SignalStatisticsDemodNode;
@@ -1040,6 +1043,9 @@ protected:
 		eDefaultNetworkDual = 4,		// Dual Mode (BS/CS110とUHF/CATV)
 	};
 	enumDefaultNetwork m_nDefaultNetwork;
+
+	// フィルタグラフをRunningObjectTableに登録するかどうか
+	BOOL m_bRegisterGraphInROT;
 
 	// Tuner is opened
 	BOOL m_bOpened;

--- a/BonDriver_BDA/BonTuner.h
+++ b/BonDriver_BDA/BonTuner.h
@@ -574,6 +574,9 @@ protected:
 	// WaitTsStreamで最低限待機する時間
 	unsigned int m_nWaitTsSleep;
 
+	// ヌルパケットを削除するかどうか
+	BOOL m_bDeleteNullPackets;
+
 	// SetChannel()でチャンネルロックに失敗した場合でもFALSEを返さないようにするかどうか
 	BOOL m_bAlwaysAnswerLocked;
 
@@ -1067,6 +1070,15 @@ protected:
 
 	// TSMF処理が必要
 	BOOL m_bIsEnabledTSMF;
+
+	// ヌルパケット削除処理をリセット
+	LONG m_lResetFilter;
+
+	// TSパケットサイズ(ヌルパケット削除用)
+	size_t m_PacketSize;
+
+	// 前回処理したTSパケットバッファおよび作業用(ヌルパケット削除用)
+	std::vector<BYTE> m_FilterBuf;
 
 	// 最後にLockChannelを行った時のチューニングパラメータ
 	TuningParam m_LastTuningParam;

--- a/BonDriver_BDA/TSMF.cpp
+++ b/BonDriver_BDA/TSMF.cpp
@@ -84,7 +84,7 @@ void CTSMFParser::ParseTsBuffer(BYTE * buf, size_t len, BYTE ** newBuf, size_t *
 			SyncPacket(readBuf + readBufPos, readBufSize - readBufPos, &truncate, &PacketSize);
 			// TSパケット先頭までのデータを切り捨てる
 			readBufPos += truncate;
-			if (PacketSize == 0)
+			if (truncate == 0)
 				// TSバッファのデータサイズが小さすぎて同期できない
 				break;
 

--- a/BonDriver_BDA/TSMF.cpp
+++ b/BonDriver_BDA/TSMF.cpp
@@ -30,7 +30,7 @@ void CTSMFParser::Disable(void)
 	Clear();
 }
 
-void CTSMFParser::ParseTsBuffer(BYTE * buf, size_t len, BYTE ** newBuf, size_t * newBufLen)
+void CTSMFParser::ParseTsBuffer(BYTE * buf, size_t len, BYTE ** newBuf, size_t * newBufLen, BOOL deleteNullPackets)
 {
 	if (!buf || len <= 0)
 		return;
@@ -77,8 +77,10 @@ void CTSMFParser::ParseTsBuffer(BYTE * buf, size_t len, BYTE ** newBuf, size_t *
 		}
 		// 同期できている
 		if (ParseOnePacket(readBuf.data() + readBufPos, readBuf.size() - readBufPos, onid, tsid, relative)) {
-			// 必要なTSMFフレームをテンポラリバッファへ追加
-			tempBuf.insert(tempBuf.end(), readBuf.begin() + readBufPos, readBuf.begin() + readBufPos + 188);
+			WORD pid = ((readBuf[readBufPos + 1] << 8) | readBuf[readBufPos + 2]) & 0x1fff;
+			if (!deleteNullPackets || pid != 0x1fff)
+				// 必要なTSMFフレームをテンポラリバッファへ追加
+				tempBuf.insert(tempBuf.end(), readBuf.begin() + readBufPos, readBuf.begin() + readBufPos + 188);
 		}
 		// 次のRead位置へ
 		readBufPos += PacketSize;

--- a/BonDriver_BDA/TSMF.h
+++ b/BonDriver_BDA/TSMF.h
@@ -5,6 +5,9 @@
 
 class CTSMFParser
 {
+public:
+	static constexpr BYTE TS_PACKET_SYNC_BYTE = 0x47;		// TSパケットヘッダ同期バイトコード
+
 private:
 	int slot_counter;										// TSMF多重フレームスロット番号
 	WORD TSID;												// 抽出するストリームのTSIDまたは相対TS番号
@@ -29,7 +32,6 @@ private:
 		BYTE emergency_indicator;							// 緊急警報指示
 		BYTE relative_stream_number[52];					// 相対ストリーム番号対スロット対応情報
 	} TSMFData;												// TSMF多重フレームヘッダ情報
-	static constexpr BYTE TS_PACKET_SYNC_BYTE = 0x47;		// TSパケットヘッダ同期バイトコード
 
 public:
 	// コンストラクタ
@@ -41,7 +43,9 @@ public:
 	// TSMF処理を無効にする
 	void Disable(void);
 	// TSバッファのTSMF処理を行う
-	void ParseTsBuffer(BYTE * buf, size_t len, BYTE ** newBuf, size_t * newBufLen);
+	void ParseTsBuffer(BYTE * buf, size_t len, BYTE ** newBuf, size_t * newBufLen, BOOL deleteNullPackets);
+	// TSパケットの同期を行う
+	static BOOL SyncPacket(const BYTE * buf, size_t len, size_t * truncate, size_t * packetSize);
 
 private:
 	// 全ての情報をクリア
@@ -50,6 +54,4 @@ private:
 	BOOL ParseTSMFHeader(const BYTE * buf, size_t len);
 	// 1パケット(1フレーム)の処理を行う
 	BOOL ParseOnePacket(const BYTE * buf, size_t len, WORD onid, WORD tsid, BOOL relative);
-	// TSパケットの同期を行う
-	BOOL SyncPacket(const BYTE * buf, size_t len, size_t * truncate, size_t * packetSize);
 };

--- a/BonDriver_BDA/TSMF.h
+++ b/BonDriver_BDA/TSMF.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Windows.h>
+#include <vector>
 
 class CTSMFParser
 {
@@ -12,9 +13,8 @@ private:
 	BOOL IsClearCalled;										// 解析処理のクリアが必要かどうか
 	CRITICAL_SECTION csClear;								// クリア処理を排他
 	size_t PacketSize;										// TSパケットサイズ
-	BYTE * prevBuf;											// 前回処理したTSパケットバッファ(未処理半端分保存用)
-	size_t prevBufSize;										// 前回処理したTSパケットバッファのサイズ
-	size_t prevBufPos;										// 前回処理したTSパケットバッファの処理開始位置
+	std::vector<BYTE> readBuf;								// 前回処理したTSパケットバッファ(未処理半端分保存用)およびRead用
+	std::vector<BYTE> tempBuf;								// Write用テンポラリバッファ
 	struct {
 		BYTE continuity_counter;							// 連続性指標
 		BYTE version_number;								// 変更指示

--- a/BonDriver_BDA/TSMF.h
+++ b/BonDriver_BDA/TSMF.h
@@ -9,6 +9,8 @@ private:
 	WORD TSID;												// 抽出するストリームのTSIDまたは相対TS番号
 	WORD ONID;												// 抽出するストリームのONID
 	BOOL IsRelative;										// 相対TS番号で指定するかどうか FALSE..ONID/TSIDで指定, TRUE..相対TS番号で指定
+	BOOL IsClearCalled;										// 解析処理のクリアが必要かどうか
+	CRITICAL_SECTION csClear;								// クリア処理を排他
 	size_t PacketSize;										// TSパケットサイズ
 	BYTE * prevBuf;											// 前回処理したTSパケットバッファ(未処理半端分保存用)
 	size_t prevBufSize;										// 前回処理したTSパケットバッファのサイズ
@@ -43,11 +45,11 @@ public:
 
 private:
 	// 全ての情報をクリア
-	void Clear(void);
+	void Clear(WORD onid = 0xffff, WORD tsid = 0xffff, BOOL relative = FALSE);
 	// TSMFヘッダの解析を行う
 	BOOL ParseTSMFHeader(const BYTE * buf, size_t len);
 	// 1パケット(1フレーム)の処理を行う
-	BOOL ParseOnePacket(const BYTE * buf, size_t len);
+	BOOL ParseOnePacket(const BYTE * buf, size_t len, WORD onid, WORD tsid, BOOL relative);
 	// TSパケットの同期を行う
 	BOOL SyncPacket(const BYTE * buf, size_t len, size_t * truncate, size_t * packetSize);
 };

--- a/doc/BonDriver_BDA.sample.ini
+++ b/doc/BonDriver_BDA.sample.ini
@@ -582,6 +582,18 @@
 ;DefaultNetwork="SPHD"
 ;
 ;
+;;;;
+;;;;    RegisterGraphInROT
+;;;;
+; フィルタグラフをRunningObjectTableに登録するかどうか
+;    0 または NO  .. 登録しない
+;    1 または YES .. 登録する
+; GraphEditなどを使ってフィルタグラフをデバッグするときに使います。
+;
+;   (デフォルト)
+;RegisterGraphInROT=NO
+;
+;
 [BonDriver]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; BonDriver パラメータ

--- a/doc/BonDriver_BDA.sample.ini
+++ b/doc/BonDriver_BDA.sample.ini
@@ -594,6 +594,28 @@
 ;RegisterGraphInROT=NO
 ;
 ;
+;;;;
+;;;;    PowerSetOnOpenedGUID
+;;;;
+; チューナーオープン時に電源プランを変更する場合、変更する電源設定GUID
+; 基本的にPowerSetOnClosingGUIDとセットで使います。
+; 電源設定GUID(36文字)は"powercfg /list"コマンドで取得できます。
+; 特定環境やチューナーにおいて省電力機能(可変クロック等)などに弱くドロップするときに使います。
+;
+;   (デフォルト:変更しない)
+;PowerSetOnOpenedGUID=""
+;
+;
+;;;;
+;;;;    PowerSetOnClosingGUID
+;;;;
+; 最後のチューナークローズ時に電源プランを変更する(戻す)場合、変更する電源設定GUID
+; 基本的にPowerSetOnOpenedGUIDとセットで使います。
+;
+;   (デフォルト:変更しない)
+;PowerSetOnClosingGUID=""
+;
+;
 [BonDriver]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; BonDriver パラメータ

--- a/doc/BonDriver_BDA.sample.ini
+++ b/doc/BonDriver_BDA.sample.ini
@@ -645,6 +645,19 @@
 ;
 ;
 ;;;;
+;;;;    DeleteNullPackets
+;;;;
+; GetTsStream()で返却するストリームデータからヌルパケットを削除するかどうか
+;    0 または NO  .. 削除しない
+;    1 または YES .. 削除する
+; TSMF等に含まれるヌルパケットがBonDriver共有ツールなどで転送するさい邪魔になる場合などに使う。
+; ストリームデータ返却後にTSMFの処理を行う予定があるときは使うべきでない。
+;
+;   (デフォルト)
+;DeleteNullPackets=NO
+;
+;
+;;;;
 ;;;;    AlwaysAnswerLocked
 ;;;;
 ; SetChannel()でチャンネルロックに失敗した場合でもFALSEを返さないようにするかどうか


### PR DESCRIPTION
前半3つのコミットは些末な修正で機能追加はありません。コミット 48b8d6b996a36b20a4d5b946b6f75f02dfb17a1e はデストラクタでのprevBufの解放漏れの修正を兼ねます。
コミット 3a00a2369ebf3ac9ee2fb32fe0af019374f3afb9 は表題通りで、同様の機能が実装されているBonDriver共有ツールはあるのですが、必要な他のパケットまで一緒に消してしまったりするのでこちらにも搭載されていると便利だと思いました。
コミット 982abb10a170678edb544d367d4faa1db035eb30 は、特定のチューナーとPCの組み合わせでCPU可変クロック動作中にドロップが多発することが分かったため、チューナー起動中だけ電源プラン (↓これ) を切り替えられる機能をつけたものです。
![powersetting](https://user-images.githubusercontent.com/2673799/189122851-4cf18504-71bb-472e-922e-98988978be9f.png)
似たような問題を抱える人がいるかどうかはわかりませんが、最小・最大のプロセッサの状態を同値にした電源プランを用意することで非常に安定します。
